### PR TITLE
feat(deb): hobot-configs adds dependency on udisks2

### DIFF
--- a/mk_debs.sh
+++ b/mk_debs.sh
@@ -227,7 +227,7 @@ function make_debian_deb() {
         gen_contrl_file "${deb_dst_dir}/DEBIAN" "${pkg_name}" "${pkg_version}" "${pkg_description}"
 
         # set Depends
-        sed -i 's/Depends: .*$/Depends: hobot-boot/' ${deb_dst_dir}/DEBIAN/control
+        sed -i 's/Depends: .*$/Depends: hobot-boot, udisks2/' ${deb_dst_dir}/DEBIAN/control
 
         is_allowed=1
         ;;


### PR DESCRIPTION
Summary:
    1. Update from the old version and install udisks2 to support NTFS file system mounting function