### PR TITLE
feat(desktop): Del audacity

### DIFF
--- a/samples/ubuntu-focal-desktop-arm64-packages
+++ b/samples/ubuntu-focal-desktop-arm64-packages
@@ -1,4 +1,3 @@
-audacity
 blueman
 fcitx
 fcitx-config-gtk


### PR DESCRIPTION
Summary:
    1. Audacity has a bug in recording audio subboards. You need to open pulseaudio before it can be used normally.